### PR TITLE
Issue #3089259 Revert private members on the widget class back to protected

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -1,0 +1,3 @@
+* Error: Call to a member function uuid() on null
+  * https://www.drupal.org/files/issues/2020-06-09/moderation_state_widget-3089259-7.patch
+

--- a/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
+++ b/src/Plugin/Field/FieldWidget/ModerationStateWidget.php
@@ -32,21 +32,21 @@ final class ModerationStateWidget extends BaseModerationStateWidget {
    *
    * @var \Drupal\lightning_scheduler\TransitionManager
    */
-  private $transitionManager;
+  protected $transitionManager;
 
   /**
    * The current entity.
    *
    * @var \Drupal\Core\Entity\FieldableEntityInterface
    */
-  private $entity;
+  protected $entity;
 
   /**
    * The config factory.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
-  private $configFactory;
+  protected $configFactory;
 
   /**
    * Constructs a new ModerationStateWidget object.


### PR DESCRIPTION
Upstream issue: https://www.drupal.org/project/lightning_scheduler/issues/3089259#comment-13680900